### PR TITLE
Add version requirement for websockets due to api change in 14.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ fastapi
 uvicorn
 python-multipart
 numpy
-websockets
+websockets<14
 scipy
 google-generativeai
 pytest


### PR DESCRIPTION
websockets 在 14.0 的时候换成了 asyncio 实现，和当前项目中使用的 api 不兼容。
https://websockets.readthedocs.io/en/stable/howto/upgrade.html