### PR TITLE
fix bluetooth microphone bug

### DIFF
--- a/realtime_server.py
+++ b/realtime_server.py
@@ -316,6 +316,12 @@ async def websocket_endpoint(websocket: WebSocket):
                         msg = json.loads(data["text"])
                         
                         if msg.get("type") == "start_recording":
+                            # Update audio processor with client sample rate if provided
+                            client_sample_rate = msg.get("sampleRate")
+                            if client_sample_rate:
+                                logger.info(f"Setting audio processor source sample rate to {client_sample_rate}")
+                                audio_processor.source_sample_rate = int(client_sample_rate)
+
                             # Update status to connecting while initializing OpenAI
                             await websocket.send_text(json.dumps({
                                 "type": "status",

--- a/static/main.js
+++ b/static/main.js
@@ -192,7 +192,10 @@ async function startRecording() {
         if (!audioContext) await initAudio(stream);
 
         isRecording = true;
-        await ws.send(JSON.stringify({ type: 'start_recording' }));
+        await ws.send(JSON.stringify({ 
+            type: 'start_recording', 
+            sampleRate: audioContext.sampleRate 
+        }));
         
         startTimer();
         recordButton.textContent = 'Stop';


### PR DESCRIPTION
# 蓝牙麦克风无法正常采样

## 问题原因 
蓝牙耳机的特性：当你使用蓝牙耳机进行通话（录音）时，操作系统通常会将耳机切换到 HFP (Hands-Free Profile) 模式，这种模式下的采样率通常是 16000Hz (16kHz)，有时甚至更低。

服务器的默认假设：你的后端代码 (realtime_server.py) 中的 AudioProcessor 类硬编码了源采样率为 48000Hz (48kHz)。
后果：
浏览器以 16kHz 采集音频。
服务器误以为是 48kHz 音频。
重采样算法会错误地处理数据，导致音频被“压缩”或加速播放（变成像“花栗鼠”一样的声音），或者完全无法识别。这就是你感觉“很难收录进去”（即识别不出来）的原因。

## 我所做的修复
我修改了前端和后端代码，实现了采样率的自动同步：
前端 (main.js)：在开始录音时，获取当前音频上下文的实际采样率 (audioContext.sampleRate)，并通过 WebSocket 的 start_recording 消息发送给服务器。
后端 (realtime_server.py)：接收到 start_recording 消息后，读取前端传来的 sampleRate，并动态更新 AudioProcessor 的源采样率。